### PR TITLE
Flags default to name if not provided

### DIFF
--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -330,7 +330,9 @@ class EntryPoint(object):
                                      "As entrypoint does not use 'const', the use is prohibited.")
 
             if param.get("flags", None) is None:
-                raise ParameterError(f"Parameter '{arg_name:s}' does not have flags.")
+                # if flags aren't supplied, it defaults to the name
+                LOG.debug(f'Missing flags parameter. Defaulting to --{arg_name}')
+                param['flags'] = [f'--{arg_name}']
 
     def _read_config(self, cfgfile_path, section=None):
         """ Get content from config file"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-pytest>=3.6
+pytest>=5.2
 pytest-cov>=2.6
-hypothesis>=3.23.0
+hypothesis>=4.36.2
 travis-sphinx>=2.1.0
 Sphinx>=1.8.1
 sphinx-rtd-theme>=0.4.3
+attrs>=19.2.0

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -69,11 +69,6 @@ def test_wrong_param_creation_name():
         EntryPoint([{"flags": "--flag"}])
 
 
-def test_wrong_param_creation_flags():
-    with pytest.raises(ParameterError):
-        EntryPoint([{"name": "test"}])
-
-
 def test_wrong_param_creation_other():
     with pytest.raises(TypeError):
         EntryPoint([{"name": "test", "flags": "--flag", "other": "unknown"}])
@@ -85,6 +80,32 @@ def test_choices_not_iterable():
         EntryPoint([{"name": "test", "flags": "--flag",
                      "choices": 3,
                      }])
+
+
+def test_missing_flag_replaced_by_name():
+    ep = EntryPoint([{"name": "test"}])
+
+    assert len(ep.parameter[0]) == 2
+    assert ep.parameter[0]['flags'] == ['--test']
+    assert ep.parameter[0]['name'] == 'test'
+
+
+def test_missing_flag_replaced_by_name_in_multiple_lists():
+    ep = EntryPoint([{"name": "test"},
+                     {"name": "thermos_coffee"},
+                     {"name": "tee_kessel", "flags": ['--tee_kessel']}])
+
+    assert len(ep.parameter[0]) == 2
+    assert ep.parameter[0]['flags'] == ['--test']
+    assert ep.parameter[0]['name'] == 'test'
+
+    assert len(ep.parameter[1]) == 2
+    assert ep.parameter[1]['flags'] == ['--thermos_coffee']
+    assert ep.parameter[1]['name'] == 'thermos_coffee'
+
+    assert len(ep.parameter[2]) == 2
+    assert ep.parameter[2]['flags'] == ['--tee_kessel']
+    assert ep.parameter[2]['name'] == 'tee_kessel'
 
 
 # Argument Tests


### PR DESCRIPTION
Flags default to the name if they're not supplied.
Fixes #3.