### PR TITLE
Fix KeyError for unknown argument

### DIFF
--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -535,7 +535,7 @@ def add_to_arguments(args, entry_params=None, **kwargs):
 
         params = list2dict_param(entry_params)
         for key, value in kwargs.items():
-            flag = params[key]["flags"]
+            flag = params[key].get("flags", f"--{key}")
             if isinstance(flag, list):
                 flag = flag[0]
             if isinstance(value, list):


### PR DESCRIPTION
When using an unknown argument, the flags key
doesn't exist. Now defaulting to --key
Fixes #23