### PR TITLE
Fix format string error

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,16 +52,16 @@ jobs:
 
       - name: Set up env for CodeClimate (push)
         run: |
-          echo "::set-env name=GIT_BRANCH::$GITHUB_REF"
-          echo "::set-env name=GIT_COMMIT_SHA::$GITHUB_SHA"
+          echo "GIT_BRANCH=$GITHUB_REF" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
         if: github.event_name == 'push'
 
       - name: Set up env for CodeClimate (pull_request)
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "::set-env name=GIT_BRANCH::$GITHUB_HEAD_REF"
-          echo "::set-env name=GIT_COMMIT_SHA::$PR_HEAD_SHA"
+          echo "GIT_BRANCH=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHA=$PR_HEAD_SHA" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
 
       - name: Prepare CodeClimate binary

--- a/generic_parser/dict_parser.py
+++ b/generic_parser/dict_parser.py
@@ -132,7 +132,7 @@ class DictParser(object):
 
             if param.choices and any([o for o in opt if o not in param.choices]):
                 raise ArgumentError(f"All elements of '{key:s}' need to be one of "
-                                    f"'{param.choices:}', instead the list was {opt:s}.\n"
+                                    f"'{param.choices}', instead the list was {opt}.\n"
                                     f"Help: {param.help:s}")
 
         elif param.choices and opt not in param.choices:


### PR DESCRIPTION
Fixes #40

```
            if param.choices and any([o for o in opt if o not in param.choices]):
>               raise ArgumentError(f"All elements of '{key:s}' need to be one of "
                                    f"'{param.choices:}', instead the list was {opt:s}.\n"
                                    f"Help: {param.help:s}")
E               TypeError: unsupported format string passed to list.__format__
```