### PR TITLE
Fix set-env part 2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload documentation to gh-pages
         if: ${{ success() }}
-        uses: JamesIves/github-pages-deploy-action@3.6.1
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
This is necessary to completely fix #42, considering the version `3.6.1` for the action publishing our doc used set-env.
Error is fixed when moving to a newer version.