### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,17 +6,17 @@ They are organised as follows.
 ### Documentation
 
 The `documentation` workflow triggers on any push to master, builds the documentation and pushes it to the `gh-pages` branch (if the build is successful).
-It runs on `ubuntu-latest` and `Python 3.x`.
+It runs on `ubuntu-latest` and `Python 3.7`.
 
 ### Testing Suite
 
 Tests are ensured in the `tests` workflow, which triggers on all pushes.
-It runs on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.6`, `3.7` and `3.8`).
+It runs on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.7`, `3.8`, `3.9` and `3.10`).
 
 ### Test Coverage
 
 Test coverage is calculated in the `coverage` wokflow, which triggers on pushes to `master` and any push to a `pull request`.
-It runs on `ubuntu-latest` & `Python 3.x`, and reports the coverage results of the test suite to `CodeClimate`,
+It runs on `ubuntu-latest` & `Python 3.7`, and reports the coverage results of the test suite to `CodeClimate`,
 
 
 ### Regular Testing

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:  # only lowest supported Python on latest ubuntu
         os: [ubuntu-latest]
-        python-version: [3.6]
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.x]  # crons should always run latest python hence 3.x
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:  # only lowest supported Python on latest ubuntu
         os: [ubuntu-latest]
-        python-version: [3.6]
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix: # only lowest supported Python on latest ubuntu
         os: [ubuntu-latest]
-        python-version: [3.6]
+        python-version: [3.7]
 
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import pathlib
 from setuptools import setup, find_packages
 
 # Name of the module
-MODULE_NAME = 'generic_parser'
+MODULE_NAME = "generic_parser"
 
 
 # The directory containing this file
@@ -32,40 +32,36 @@ DEPENDENCIES = []
 
 # Extra dependencies for tools
 EXTRA_DEPENDENCIES = {
-                      'test': ['pytest>=5.2',
-                               'pytest-cov>=2.6',
-                               'hypothesis>=4.36.2',
-                               'attrs>=19.2.0'],
-                      'doc': ['sphinx',
-                              'travis-sphinx',
-                              'sphinx_rtd_theme']
-                      }
+    "test": ["pytest>=5.2", "pytest-cov>=2.6", "hypothesis>=4.36.2", "attrs>=19.2.0"],
+    "doc": ["sphinx", "travis-sphinx", "sphinx_rtd_theme"],
+}
 
 # The text of the README file
 with README.open("r") as docs:
     long_description = docs.read()
 
-# This call to setup() does all the work
 setup(
-    name=ABOUT_GENERIC_PARSER['__title__'],
-    version=ABOUT_GENERIC_PARSER['__version__'],
-    description=ABOUT_GENERIC_PARSER['__description__'],
+    name=ABOUT_GENERIC_PARSER["__title__"],
+    version=ABOUT_GENERIC_PARSER["__version__"],
+    description=ABOUT_GENERIC_PARSER["__description__"],
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url=ABOUT_GENERIC_PARSER['__url__'],
-    author=ABOUT_GENERIC_PARSER['__author__'],
-    author_email=ABOUT_GENERIC_PARSER['__author_email__'],
-    license=ABOUT_GENERIC_PARSER['__license__'],
+    url=ABOUT_GENERIC_PARSER["__url__"],
+    author=ABOUT_GENERIC_PARSER["__author__"],
+    author_email=ABOUT_GENERIC_PARSER["__author_email__"],
+    license=ABOUT_GENERIC_PARSER["__license__"],
     python_requires=">=3.6",
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-    packages=find_packages(include=('generic_parser',)),
+    packages=find_packages(include=("generic_parser",)),
     install_requires=DEPENDENCIES,
-    tests_require=EXTRA_DEPENDENCIES['test'],
-    extras_require=EXTRA_DEPENDENCIES
+    tests_require=EXTRA_DEPENDENCIES["test"],
+    extras_require=EXTRA_DEPENDENCIES,
 )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This series of PRs (see other repos):

- Removes Python `3.6` from our CI setups as it has reached EOL
- Adds Python `3.10`
- Updates CI readmes
- Updates classifiers