### PR TITLE
Argparse options

### DIFF
--- a/generic_parser/__init__.py
+++ b/generic_parser/__init__.py
@@ -5,7 +5,7 @@ from generic_parser.tools import DotDict
 __title__ = "generic_parser"
 __description__ = "A parser for arguments and config-files that also allows direct python input."
 __url__ = "https://github.com/pylhc/generic_parser"
-__version__ = "1.0.9"
+__version__ = "1.1.0"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/generic_parser/dict_parser.py
+++ b/generic_parser/dict_parser.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 # Parser #######################################################################
 
 
-class DictParser(object):
+class DictParser:
     """
     Provides functions to parse a dictionary.
 
@@ -393,7 +393,7 @@ class ArgumentError(Exception):
     pass
 
 
-class Parameter(object):
+class Parameter:
     """Helper Class for DictParser."""
     def __init__(self, name, **kwargs):
         self.name = name

--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -163,6 +163,7 @@ or as commandline arguments from a **script.py** that calls ``entry_function()``
 import copy
 import json
 import argparse
+import sys
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from inspect import getfullargspec
@@ -170,7 +171,7 @@ from functools import wraps
 from pathlib import Path
 from textwrap import wrap
 
-from generic_parser.tools import DotDict, silence, unformatted_console_logging
+from generic_parser.tools import DotDict, silence, unformatted_console_logging, StringIO, log_out
 from generic_parser.dict_parser import ParameterError, ArgumentError, DictParser
 
 import logging
@@ -187,7 +188,7 @@ ID_SECTION = "section"
 
 
 class EntryPoint(object):
-    def __init__(self, parameter, strict=False):
+    def __init__(self, parameter, strict=False, argument_parser_args=None, print_help=None):
         """Initialize decoration: Handle the desired input parameter."""
         self.strict = strict
 
@@ -203,8 +204,9 @@ class EntryPoint(object):
         # this also ensures that the parameters are correctly defined,
         # by tests in argparser and in Parameter(),
         # which is used in dict_parser -> add parameter
-        self.argparse = self._create_argument_parser()
+        self.argparse = self._create_argument_parser(argument_parser_args)
         self.dictparse = self._create_dict_parser()  # also used for configfiles
+        self._print_help = print_help
 
     def parse(self, *args, **kwargs):
         """
@@ -252,9 +254,14 @@ class EntryPoint(object):
         parser.add_argument('--{}'.format(ID_SECTION), type=str, dest=ID_SECTION,)
         return parser
 
-    def _create_argument_parser(self):
+    def _create_argument_parser(self, args_dict):
         """Creates the ArgumentParser from parameter."""
-        parser = ArgumentParser()
+
+        if args_dict:
+            parser = ArgumentParser(**args_dict)
+        else:
+            parser = ArgumentParser()
+
         parser = _add_params_to_argument_parser(parser, self.parameter)
         return parser
 
@@ -281,7 +288,26 @@ class EntryPoint(object):
                 options = self.configarg.parse_args(args)
         except SystemExit:
             # parse regular options
-            options, unknown_opts = self.argparse.parse_known_args(args)
+            errors_io = StringIO()
+            try:
+                with log_out(stderr=errors_io):  # errors go into errors_io
+                    options, unknown_opts = self.argparse.parse_known_args(args)
+            except SystemExit as e:
+                errors_str = errors_io.getvalue()
+                # print help on wrong input
+                if self._print_help and e.code == 2:  # code 0 means help has been printed
+                    self._print_help(self.argparse.format_help())
+                    # remove duplicated "usage" line
+                    errors_str = "\n".join(errors_str.split("\n")[1:])
+
+                # print errors now (if any)
+                sys.stderr.write(errors_str)
+                raise e
+
+            # print help, even if passed on to other parser
+            if self._print_help and "--help" in unknown_opts:
+                self._print_help(self.argparse.format_help())
+
             options = DotDict(vars(options))
             if self.strict:
                 if unknown_opts:

--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -170,6 +170,7 @@ from inspect import getfullargspec
 from functools import wraps
 from pathlib import Path
 from textwrap import wrap
+from typing import Callable, Mapping
 
 from generic_parser.tools import DotDict, silence, unformatted_console_logging, StringIO, log_out
 from generic_parser.dict_parser import ParameterError, ArgumentError, DictParser
@@ -187,8 +188,8 @@ ID_SECTION = "section"
 # EntryPoint Class #############################################################
 
 
-class EntryPoint(object):
-    def __init__(self, parameter, strict=False, argument_parser_args=None, help_printer=None):
+class EntryPoint:
+    def __init__(self, parameter, strict: bool = False, argument_parser_args: Mapping = None, help_printer: Callable = None):
         """Initialize decoration: Handle the desired input parameter."""
         self.strict = strict
 
@@ -254,7 +255,7 @@ class EntryPoint(object):
         parser.add_argument('--{}'.format(ID_SECTION), type=str, dest=ID_SECTION,)
         return parser
 
-    def _create_argument_parser(self, args_dict):
+    def _create_argument_parser(self, args_dict: Mapping):
         """Creates the ArgumentParser from parameter."""
 
         if args_dict:

--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -188,7 +188,7 @@ ID_SECTION = "section"
 
 
 class EntryPoint(object):
-    def __init__(self, parameter, strict=False, argument_parser_args=None, print_help=None):
+    def __init__(self, parameter, strict=False, argument_parser_args=None, help_printer=None):
         """Initialize decoration: Handle the desired input parameter."""
         self.strict = strict
 
@@ -206,7 +206,7 @@ class EntryPoint(object):
         # which is used in dict_parser -> add parameter
         self.argparse = self._create_argument_parser(argument_parser_args)
         self.dictparse = self._create_dict_parser()  # also used for configfiles
-        self._print_help = print_help
+        self._help_printer = help_printer
 
     def parse(self, *args, **kwargs):
         """
@@ -295,8 +295,8 @@ class EntryPoint(object):
             except SystemExit as e:
                 errors_str = errors_io.getvalue()
                 # print help on wrong input
-                if self._print_help and e.code == 2:  # code 0 means help has been printed
-                    self._print_help(self.argparse.format_help())
+                if self._help_printer and e.code == 2:  # code 0 means help has been printed
+                    self._help_printer(self.argparse.format_help())
                     # remove duplicated "usage" line
                     errors_str = "\n".join(errors_str.split("\n")[1:])
 
@@ -305,8 +305,8 @@ class EntryPoint(object):
                 raise e
 
             # print help, even if passed on to other parser
-            if self._print_help and "--help" in unknown_opts:
-                self._print_help(self.argparse.format_help())
+            if self._help_printer and "--help" in unknown_opts:
+                self._help_printer(self.argparse.format_help())
 
             options = DotDict(vars(options))
             if self.strict:

--- a/generic_parser/entrypoint_parser.py
+++ b/generic_parser/entrypoint_parser.py
@@ -298,7 +298,7 @@ class EntryPoint(object):
                 if self._help_printer and e.code == 2:  # code 0 means help has been printed
                     self._help_printer(self.argparse.format_help())
                     # remove duplicated "usage" line
-                    errors_str = "\n".join(errors_str.split("\n")[1:])
+                    errors_str = "\n".join(errors_str.split("\n")[-2:])
 
                 # print errors now (if any)
                 sys.stderr.write(errors_str)


### PR DESCRIPTION
This modification allows you to 
a) give arguments to the argparser
b) have the argparser print the help, whenever he fails
c) have the argparser print help when --help is present, but ALSO PASSES THIS ON in the unknown opts.

Let me know what you think.

Example:

```python
from pathlib import Path

from generic_parser import entrypoint, EntryPointParameters, EntryPoint
import sys


def get_params():
    return EntryPointParameters(
        test=dict(
            help="This is a test parameter",
            type=str,
            choices=["alpha", "beta"],
            required=True,
        ),
        blubb=dict(
            help="Another test parameter",
            type=int,
            choices=[1, 2, 3, 4],
            default=4,
        )
    )


def get_other_params():
    return EntryPointParameters(
        happy=dict(
            help="This is a test parameterf asf",
            type=str,
            choices=["alpha", "beta"],
            required=True,
        ),
        nothappy=dict(
            help="Another test parameter fsfs",
            type=int,
            choices=[1, 2, 3, 4],
            default=4,
        )
    )


@entrypoint(get_params(), argument_parser_args=dict(add_help=False), strict=False, help_printer=print)
def main(opt, uopt):
    # print(opt)
    # print(uopt)

    ep = EntryPoint(get_other_params(),
                    argument_parser_args=dict(add_help=True, prog=f"{Path(__file__).name}(cont)"),
                    strict=True)
    # print(ep.argparse.format_help())
    print(ep.parse(uopt))


if __name__ == '__main__':
    # sys.argv = ["fsf", "--test", "alpha", "--help"]
    # sys.argv = ["fsf", "--test", "alpha", "--happy", "beta", "--help"]
    # sys.argv = ["fsf", "--help"]
    main()
  ```