### PR TITLE
Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Generic-Parser Changelog
 
+## Version 1.1.2
+  * Dropped support for `Python 3.9`.
+
 ## Version 1.1.1
  * add a dictionary to the eval in DictFromString to allow reading in *.ini with nans
- 
+
 
 ## Version 1.0.8
  * revamp of the documentation
@@ -11,7 +14,7 @@
 
 ## Version 1.0.7
  * fixed crash before proper error message for invalid choice of non-string
- objects. 
+ objects.
  * fixed: Paths can be handled by `save_options_to_config` (converted to strings)
  * fixed: Quotes around Paths are stripped from config files on reading
  * fixes: Strings with linebreaks are now written properly with `save_options_to_config`
@@ -20,7 +23,7 @@
  * improved `create_parameter_help` function.
  * some documentation fixed/additions.
  * switched to github actions for CI.
- 
+
 
 ## Version 1.0.6
  * Fix KeyError for unknown flags
@@ -36,7 +39,7 @@
    * pep8 errors and warnings
    * typo in logging
  * Enhancement:
-   * Flags default to name if not set 
+   * Flags default to name if not set
 
 ## Version 1.0.2
  - Fixed:

--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ See the [API documentation](https://pylhc.github.io/generic_parser/) for details
 ## Installing
 
 Installation is easily done via `pip`. The package is then used as `generic_parser`.
+
 ```bash
 python -m pip install generic-parser
 ```
 
 One can also install in a `conda` environment via the `conda-forge` channel with:
+
 ```bash
 conda install -c conda-forge generic_parser
 ```
 
-## Example Usage:
+## Example
 
 Content of `myscript.py`
+
 ```python
 from generic_parser import entrypoint, EntryPointParameters
 
@@ -63,7 +66,8 @@ if __name__ == '__main__':
 ### Commandline
 
 Calling that script with ``python myscript.py -f 1 -s "test"`` will result in:
-```
+
+```bash
 True
 False
 ```
@@ -73,14 +77,16 @@ It is assumed, that this is the standard mode of operation for your functions.
 #### Config File
 
 Further, one can also use a config file `config.ini` containing:
-```
+
+```ini
 [Section]
 first = 2
 second = "Hello"
 ```
 
 and run the script with `python myscript.py --entry_cfg config.ini` leading to
-```
+
+```bash
 False
 False
 ```
@@ -90,13 +96,15 @@ Especially the declaration of a `[DEFAULT]` section can be helpful.
 For further information about config files, check the python [Config Parser](https://docs.python.org/3/library/configparser.html).
 
 ### Python
+
 Or call the function directly from python code:
+
 ```python
 if __name__ == '__main__':
     main(first=1, second="World")
 ```
 
-```
+```python
 True
 False
 ```
@@ -110,4 +118,4 @@ which is not used in the `Entrypoint`, but can be handy in other use-cases.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Generic Parser
 
 [![Tests](https://github.com/pylhc/generic_parser/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/pylhc/generic_parser/actions/workflows/coverage.yml)
-<!-- [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/generic_parser.svg?style=popout)](https://github.com/pylhc/generic_parser/) -->
+[![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/generic_parser.svg?style=popout)](https://github.com/pylhc/generic_parser/)
 [![PyPI Version](https://img.shields.io/pypi/v/generic_parser?label=PyPI&logo=pypi)](https://pypi.org/project/generic_parser/)
 [![GitHub release](https://img.shields.io/github/v/release/pylhc/generic_parser?logo=github)](https://github.com/pylhc/generic_parser/)
 [![Conda-forge Version](https://img.shields.io/conda/vn/conda-forge/generic_parser?color=orange&logo=anaconda)](https://anaconda.org/conda-forge/generic_parser)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Generic Parser
-[![Cron Testing](https://github.com/pylhc/generic_parser/workflows/Cron%20Testing/badge.svg)](https://github.com/pylhc/generic_parser/actions?query=workflow%3A%22Cron+Testing%22)
-[![Code Climate coverage](https://img.shields.io/codeclimate/coverage/pylhc/generic_parser.svg?style=popout)](https://codeclimate.com/github/pylhc/generic_parser)
-[![Code Climate maintainability (percentage)](https://img.shields.io/codeclimate/maintainability-percentage/pylhc/generic_parser.svg?style=popout)](https://codeclimate.com/github/pylhc/generic_parser)
+
+[![Tests](https://github.com/pylhc/generic_parser/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/pylhc/generic_parser/actions/workflows/coverage.yml)
 <!-- [![GitHub last commit](https://img.shields.io/github/last-commit/pylhc/generic_parser.svg?style=popout)](https://github.com/pylhc/generic_parser/) -->
 [![PyPI Version](https://img.shields.io/pypi/v/generic_parser?label=PyPI&logo=pypi)](https://pypi.org/project/generic_parser/)
 [![GitHub release](https://img.shields.io/github/v/release/pylhc/generic_parser?logo=github)](https://github.com/pylhc/generic_parser/)

--- a/generic_parser/__init__.py
+++ b/generic_parser/__init__.py
@@ -5,7 +5,7 @@ from generic_parser.tools import DotDict
 __title__ = "generic_parser"
 __description__ = "A parser for arguments and config-files that also allows direct python input."
 __url__ = "https://github.com/pylhc/generic_parser"
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ changelog = "https://github.com/pylhc/generic_parser/blob/master/CHANGELOG.md"
 
 # ----- Testing ----- #
 
+[tool.pytest.ini_options]
+addopts = "--cov-report=xml --cov-report term-missing --cov-config=pyproject.toml --cov=generic_parser"
+testpaths = ["tests"]
+
 [tool.coverage.run]
 source = ["generic_parser/"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,17 +24,18 @@ authors = [
 ]
 license = "MIT"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,19 +63,6 @@ repository = "https://github.com/pylhc/generic_parser"
 documentation = "https://pylhc.github.io/generic_parser/"
 changelog = "https://github.com/pylhc/generic_parser/blob/master/CHANGELOG.md"
 
-# ----- Testing ----- #
-
-[tool.coverage.run]
-source = ["generic_parser/"]
-
-[tool.coverage.report]
-precision = 2
-ignore_errors = true
-exclude_also = [
-  "if TYPE_CHECKING:",  # do not count if TYPE_CHECKING block imports (ignored at runtime) for coverage
-  "except ImportError:",  # do not count missing optional dependencies set to None, we monkeypatch and test that
-]
-
 # ----- Dev Tools Configuration ----- #
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,14 @@ changelog = "https://github.com/pylhc/generic_parser/blob/master/CHANGELOG.md"
 # ----- Testing ----- #
 
 [tool.pytest.ini_options]
-addopts = "--cov-report=xml --cov-report term-missing --cov-config=pyproject.toml --cov=generic_parser"
-testpaths = ["tests"]
+addopts = [
+    "--import-mode=importlib",
+]
 
 [tool.coverage.run]
-source = ["generic_parser/"]
+relative_files = true
 
 [tool.coverage.report]
-precision = 2
-ignore_errors = true
 exclude_also = [
   "if TYPE_CHECKING:",  # do not count if TYPE_CHECKING block imports (ignored at runtime) for coverage
   "except ImportError:",  # do not count missing optional dependencies set to None, we monkeypatch and test that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,19 @@ repository = "https://github.com/pylhc/generic_parser"
 documentation = "https://pylhc.github.io/generic_parser/"
 changelog = "https://github.com/pylhc/generic_parser/blob/master/CHANGELOG.md"
 
+# ----- Testing ----- #
+
+[tool.coverage.run]
+source = ["generic_parser/"]
+
+[tool.coverage.report]
+precision = 2
+ignore_errors = true
+exclude_also = [
+  "if TYPE_CHECKING:",  # do not count if TYPE_CHECKING block imports (ignored at runtime) for coverage
+  "except ImportError:",  # do not count missing optional dependencies set to None, we monkeypatch and test that
+]
+
 # ----- Dev Tools Configuration ----- #
 
 [tool.ruff]


### PR DESCRIPTION
Drop Python 3.9, add coverage config options (as done in `omc3`), remove CodeClimate and update coverage badge on readme, some markdown linting.